### PR TITLE
Add clang-format helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: format lint
+
+format:
+	clang-format -i src/*.cpp src/*.h
+
+lint:
+	clang-format --dry-run --Werror src/*.cpp src/*.h

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ Penguin programming language
 
 **You can run ``scripts/make.cmd`` (for Windows) or ``scripts/make.sh`` (for Linux) to do that or use ``CMakeLists.txt``**
 
-### Formatting
-Run ``make format`` to apply ``clang-format`` to the source files. Use ``make lint`` to check formatting without modifying files.
 ## Usage
 ``Penguin path/to/program.peng``  
 ## Examples

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Penguin programming language
 **You have to compile all files from ``src/``**  
 
 **You can run ``scripts/make.cmd`` (for Windows) or ``scripts/make.sh`` (for Linux) to do that or use ``CMakeLists.txt``**
+
+### Formatting
+Run ``make format`` to apply ``clang-format`` to the source files. Use ``make lint`` to check formatting without modifying files.
 ## Usage
 ``Penguin path/to/program.peng``  
 ## Examples

--- a/src/Main.h
+++ b/src/Main.h
@@ -101,7 +101,7 @@ public:
   std::string stringValue;
   double doubleValue = 0.0;
   bool boolValue = false;
-  explicit Variable(int t) : type(t) {};
+  explicit Variable(int t) : type(t) {}
 };
 
 class expressionElement {


### PR DESCRIPTION
## Summary
- add a Makefile with convenient `format` and `lint` targets for clang-format
