### PR TITLE
Add modular unit tests and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,16 +54,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: penguin-binary
-          path: build
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake
 
-      - name: Make artifact executable
-        run: chmod +x build/Penguin
-
-      - name: Run tests
-        env:
-          PENGUIN_EXE: ./build/Penguin
-        run: bash scripts/tests.sh
+      - name: Run unit and integration tests
+        run: make run_tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,13 +5,23 @@ set(CMAKE_CXX_STANDARD 17)
 
 include_directories(.)
 
-add_executable(Penguin
+set(PENGUIN_SOURCES
         src/LexicalAnalyzer.cpp
         src/Main.h
         src/Math.h
-        src/Penguin.cpp
         src/LexicalAnalyzer.h
         src/SyntaxAnalyzer.cpp
         src/SyntaxAnalyzer.h
         src/Executor.cpp
         src/Executor.h)
+
+add_library(penguin_lib ${PENGUIN_SOURCES})
+target_include_directories(penguin_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+add_executable(Penguin src/Penguin.cpp)
+target_link_libraries(Penguin PRIVATE penguin_lib)
+
+enable_testing()
+add_executable(PenguinTests tests/test_main.cpp)
+target_link_libraries(PenguinTests PRIVATE penguin_lib)
+add_test(NAME penguin_unit_tests COMMAND PenguinTests)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
-.PHONY: format lint
+.PHONY: format lint run_tests
 
 format:
 	clang-format -i src/*.cpp src/*.h
 
 lint:
 	clang-format --dry-run --Werror src/*.cpp src/*.h
+
+run_tests:
+	cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+	cmake --build build --config Release
+	ctest --test-dir build
+	PENGUIN_EXE=./build/Penguin EXAMPLES_DIR=examples bash scripts/tests.sh

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Usage:
   - ``Penguin examples/power-of-two-loops/main.peng < examples/power-of-two-loops/in/1.in``
 ## Tests
 **You can run tests with ``scripts/tests.bat`` or ``scripts/tests.sh``**  
+  
+For a full test run (unit tests for core modules + example-based integration
+checks) use:
+
+```
+make run_tests
+```
 ## Docs
 * [Grammar (Google Docs)](https://docs.google.com/document/d/1y9UAdCVIHkVw3AbSU_anU4KZSvI54mrA7OSpKjKvKgw) / [Grammar (Repo docs)](https://github.com/exsandebest/Penguin/tree/master/docs/grammar.ebnf)
 * [Types of tokens (Google Sheets)](https://docs.google.com/spreadsheets/d/1OBjwfQxot8h_A8aIbHIXjujbpoGofYAS0elkgWege0g) / [Types of tokens (Repo docs)](https://github.com/exsandebest/Penguin/tree/master/docs/token_types.md)

--- a/src/LexicalAnalyzer.cpp
+++ b/src/LexicalAnalyzer.cpp
@@ -15,6 +15,16 @@ void addToken(int type, const std::string &value) {
   tokens.push_back(new Token(type, value, line));
 }
 
+// Resets lexical analyzer state for a fresh run (used by tests)
+void resetLexicalAnalyzer() {
+  for (auto *token : tokens) {
+    delete token;
+  }
+  tokens.clear();
+  s.clear();
+  line = 1;
+}
+
 // Returns true if the character is a letter or digit, false otherwise
 bool ld(char c) { return isdigit(c) || isalpha(c); }
 
@@ -296,6 +306,7 @@ std::string deleteComments(std::string &str) {
 
 // Runs Lexical Analysis
 std::vector<Token *> runLexicalAnalysis(std::string input) {
+  resetLexicalAnalyzer();
   s = std::move(input);
   s = deleteComments(s);
   parse();

--- a/src/LexicalAnalyzer.h
+++ b/src/LexicalAnalyzer.h
@@ -18,6 +18,7 @@ int parseWord(int i);
 int parseNumber(int i);
 int parseString(int i);
 void addToken(int type, const std::string &value);
+void resetLexicalAnalyzer();
 bool ld(char c);
 std::vector<Token *> runLexicalAnalysis(std::string input);
 

--- a/src/SyntaxAnalyzer.cpp
+++ b/src/SyntaxAnalyzer.cpp
@@ -47,6 +47,32 @@ vector<int> posOfEndCnt;   // Counters for loop end positions
 vector<int> posOfEndIf;    // End positions of if statements in RPN
 vector<int> posOfEndCntIf; // Counters for if statement end positions
 
+void resetSyntaxAnalyzerState() {
+  debug = false;
+  nestingLevel = 0;
+  currentFunctionType = -1;
+  curPos = -1;
+  CurrentFunction.clear();
+  v.clear();
+  cur = nullptr;
+  while (!stateStack.empty())
+    stateStack.pop();
+  stateSet.clear();
+  names.clear();
+  while (!lastNames.empty())
+    lastNames.pop();
+  functionHasReturn.clear();
+  rpnMap.clear();
+  rpnNames.clear();
+  while (!rpnLastNames.empty())
+    rpnLastNames.pop();
+  posOfStart.clear();
+  posOfEnd.clear();
+  posOfEndCnt.clear();
+  posOfEndIf.clear();
+  posOfEndCntIf.clear();
+}
+
 // Function Declarations
 
 // Returns an error message string, includes unexpected token or a custom error

--- a/src/SyntaxAnalyzer.h
+++ b/src/SyntaxAnalyzer.h
@@ -53,5 +53,6 @@ void debugRpn(const std::string &fun);
 PToken exec(const std::string &functionName, std::vector<PToken> args,
             int nestLvl);
 int runLexicalAnalysis(std::vector<Token *> tokens, bool debugFlag);
+void resetSyntaxAnalyzerState();
 
 #endif // PENGUIN_SYNTAXANALYZER_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,162 @@
+#include "Executor.h"
+#include "LexicalAnalyzer.h"
+#include "Math.h"
+#include "SyntaxAnalyzer.h"
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void expect(bool condition, const std::string &message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+template <typename L, typename R>
+void expectEqual(const L &actual, const R &expected,
+                 const std::string &message) {
+  if (actual != expected) {
+    throw std::runtime_error(message);
+  }
+}
+
+void expectThrow(const std::function<void()> &fn,
+                 const std::string &message) {
+  bool threw = false;
+  try {
+    fn();
+  } catch (const std::runtime_error &) {
+    threw = true;
+  }
+  if (!threw) {
+    throw std::runtime_error(message);
+  }
+}
+
+void testLexicalTokenization() {
+  auto tokens = runLexicalAnalysis("int x = 5;\nwrite(x);");
+
+  expectEqual(tokens.size(), static_cast<size_t>(10),
+              "Unexpected token count for simple program");
+  expectEqual(tokens[0]->type, variableType,
+              "First token should be variable type");
+  expectEqual(tokens[1]->type, name, "Second token should be variable name");
+  expectEqual(tokens[5]->type, readwriteOperator,
+              "write should be parsed as read/write operator");
+  expectEqual(tokens[5]->line, 2, "write token should be on the second line");
+
+  resetLexicalAnalyzer();
+  resetSyntaxAnalyzerState();
+}
+
+void testLexicalCommentsPreserveLines() {
+  std::string input = "int x = 1; /* comment\nstill comment */ int y = 2;";
+  auto tokens = runLexicalAnalysis(input);
+
+  expectEqual(tokens.size(), static_cast<size_t>(10),
+              "Tokens with comments removed should still parse");
+  expectEqual(tokens[5]->line, 2,
+              "Second declaration should be detected on the second line");
+  resetLexicalAnalyzer();
+  resetSyntaxAnalyzerState();
+}
+
+void testLexicalRejectsBadNumbers() {
+  expectThrow([]() { runLexicalAnalysis("int x = 1..2;"); },
+              "Incorrect number constant should throw");
+  resetLexicalAnalyzer();
+  resetSyntaxAnalyzerState();
+}
+
+void testSyntaxRequiresMain() {
+  const std::string program = "int foo() { return 1; }";
+  auto tokens = runLexicalAnalysis(program);
+
+  expectThrow(
+      [&tokens]() { runLexicalAnalysis(tokens, false); },
+      "Program without main function should fail during syntax analysis");
+
+  resetSyntaxAnalyzerState();
+  resetLexicalAnalyzer();
+}
+
+void testSyntaxChecksReturnType() {
+  const std::string program =
+      "bool isPositive(int value) { return 1; }\n"
+      "null main() { return; }";
+  auto tokens = runLexicalAnalysis(program);
+
+  expectThrow(
+      [&tokens]() { runLexicalAnalysis(tokens, false); },
+      "Returning wrong type should trigger a syntax error");
+
+  resetSyntaxAnalyzerState();
+  resetLexicalAnalyzer();
+}
+
+void testExecutorEvaluatesFunctions() {
+  const std::string program =
+      "int add(int a, int b) { return a + b; }\n"
+      "null main() { return; }";
+
+  auto tokens = runLexicalAnalysis(program);
+  runLexicalAnalysis(tokens, false);
+
+  PToken left(PIntValue, "");
+  left.intValue = 2;
+  PToken right(PIntValue, "");
+  right.intValue = 3;
+
+  PToken result = execute("add", {left, right}, 0);
+  expectEqual(result.type, PIntValue, "Result of add should be an int");
+  expectEqual(result.intValue, 5, "add(2, 3) should evaluate to 5");
+
+  resetSyntaxAnalyzerState();
+  resetLexicalAnalyzer();
+}
+
+void testMathPowGuards() {
+  expectThrow([]() { peng_pow(2, -1); },
+              "Integer power should reject negative exponent");
+
+  expectThrow([]() { peng_pow(-2.0, 0.5); },
+              "Negative base with fractional power should be rejected");
+}
+
+} // namespace
+
+int main() {
+  int failures = 0;
+
+  const std::vector<std::pair<std::string, std::function<void()>>> tests = {
+      {"Lexical tokenization", testLexicalTokenization},
+      {"Lexical comment handling", testLexicalCommentsPreserveLines},
+      {"Lexical rejects bad numbers", testLexicalRejectsBadNumbers},
+      {"Syntax requires main", testSyntaxRequiresMain},
+      {"Syntax return type checking", testSyntaxChecksReturnType},
+      {"Executor function evaluation", testExecutorEvaluatesFunctions},
+      {"Math power guardrails", testMathPowGuards},
+  };
+
+  for (const auto &[name, fn] : tests) {
+    try {
+      fn();
+      std::cout << "[PASS] " << name << "\n";
+    } catch (const std::exception &ex) {
+      ++failures;
+      std::cerr << "[FAIL] " << name << ": " << ex.what() << "\n";
+    }
+  }
+
+  if (failures != 0) {
+    std::cerr << failures << " test(s) failed\n";
+    return 1;
+  }
+
+  std::cout << "All unit tests passed\n";
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add reusable library target and modular unit test suite for lexer, syntax analyzer, executor, and math helpers
- expose reset helpers to allow repeatable test runs and document the new combined test command
- run unit and integration tests via a new make run_tests target and wire it into the CI test job

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- cmake --build build --config Release
- ctest --test-dir build
- PENGUIN_EXE=./build/Penguin bash scripts/tests.sh